### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Run Prettier
         shell: bash
         run: |
-          pnpm prettier --check .
+          pnpm prettier --list-different .

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,8 @@ COPY ./back-end ./back-end
 # ensure cargo picks up on the change
 RUN touch ./back-end/src/main.rs
 
+ENV PATH="/output/bin:$PATH"
+
 # --release not needed, it is implied with install
 RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \


### PR DESCRIPTION
- **fix(ci): surpress "warning: be sure to add `/output/bin` to your PATH to be able to run the installed binaries"**
- **chore(deps): update softprops/action-gh-release action to v2.3.4**
- **fix(ci): use --list-different to actually list the files different**
